### PR TITLE
Release Gem version 0.2.7.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    crypt_ident (0.2.6)
+    crypt_ident (0.2.7)
       bcrypt
       dry-matcher
       dry-monads

--- a/lib/crypt_ident/version.rb
+++ b/lib/crypt_ident/version.rb
@@ -2,5 +2,5 @@
 
 module CryptIdent
   # Version number for Gem. Uses Semantic Versioning.
-  VERSION = '0.2.6'
+  VERSION = '0.2.7'
 end


### PR DESCRIPTION
This release:
  1. Updates Gem dependencies;
  2. Thereby fixes GitHub dependency security warning;
  3. Updates Ruby version used to build Gem to Ruby 2.6.6;
  4. Does not make any code changes other than version tag.
